### PR TITLE
Corrigindo link quebrado ElemarJR

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Este projeto visa compilar blogs de desenvolvedores da comunidade brasileira. A 
 
 #### E
 - [Eduardo Rabelo](https://medium.com/@oieduardorabelo) - Front-End
-- [Elemar Jr](http://www.elemarjr.com/pt/blog/) - Microsoft MVP, C#, Arquitetura de Software
+- [Elemar Jr](https://elemarjr.com/arquivo/) - Microsoft MVP, C#, Arquitetura de Software
 - [Erick Wendel](https://erickwendel.com/) - CVS, Arquitetura de Software, Front-End, Javascript, Node
 - [Everton Strack](https://evertonstrack.com.br/blog/) - Front-End, HTML, CSS, Javascript
 


### PR DESCRIPTION
Parece que não existe mais a sessão de blog no site de ElemarJR e os post antigos forma movidos para uma sessão de arquivo, o link para o arquivos foi colocado no lugar do antigo lugar de blogs